### PR TITLE
Update RythmFactoryBean to test if the i18n resolver is already set

### DIFF
--- a/src/main/java/org/rythmengine/spring/RythmEngineFactory.java
+++ b/src/main/java/org/rythmengine/spring/RythmEngineFactory.java
@@ -254,9 +254,11 @@ public class RythmEngineFactory extends ApplicationObjectSupport implements Phas
         // the i18 message resolver
         ApplicationContext ctx = getApplicationContext();
         if (null != ctx) {
-            SpringI18nMessageResolver i18n = new SpringI18nMessageResolver();
-            i18n.setApplicationContext(getApplicationContext());
-            p.put(RythmConfigurationKey.I18N_MESSAGE_RESOLVER.getKey(), i18n);
+        	if (!p.containsKey(RythmConfigurationKey.I18N_MESSAGE_RESOLVER.getKey())){
+            		SpringI18nMessageResolver i18n = new SpringI18nMessageResolver();
+            		i18n.setApplicationContext(getApplicationContext());
+            		p.put(RythmConfigurationKey.I18N_MESSAGE_RESOLVER.getKey(), i18n);
+        	}
         }
 
         configRythm(p);


### PR DESCRIPTION
This change will only set the i18n message resolver if its not already set in the engineConfig map (possibly through XML).
Sample XML code: 
<bean id="messageSourceService" class="com.suh.services.i18n.MessageSourceService" />
<bean id="rythmConfigurer" class="org.rythmengine.spring.web.RythmConfigurer">
              <property name="resourceLoaderPath" value="/WEB-INF/views/rythm/"/>
              <property name="engineConfig">
                     <map>
                            <entry key="engine.file_write.enabled" value="false"></entry>
                            <entry key="i18n.message.resolver.impl" value-ref="messageSourceService"></entry>
                            <entry key="rythm.i18n.locale" value="gb_EN"></entry>
                     </map>
              </property>

```
   </bean>
```
